### PR TITLE
Remove sudo usage and extract disk image with 7zip instead

### DIFF
--- a/gen-sdk.sh
+++ b/gen-sdk.sh
@@ -2,6 +2,16 @@
 
 set -e # Stop on error
 
+# 7zip CLI may be installed as "7z" or "7zz" depending on the distribution
+sevenzip=7z
+if ! command -v $sevenzip >/dev/null 2>&1; then
+    sevenzip=7zz
+    if ! command -v $sevenzip >/dev/null 2>&1; then
+        echo "[ERROR] 7z (or 7zz) not found! Please install 7zip to continue."
+        exit 1
+    fi
+fi
+
 RM_If_Exists() {
     if [ -d $1 ] || [ -f $1 ]; then
         rm -rf $1
@@ -17,10 +27,9 @@ Setup_SDK() {
     fi
     sysroot_dir="$tc_dir/$tc_target/sysroot"
 
-    # Just in case
-    set +e
-    sudo umount ./cache/${tc_target}/firmware*/mnt
-    set -e
+    # If a previous version of this script left a mount around, clean it up
+    sudo umount ./cache/${tc_target}/firmware*/mnt || true
+    rm -rf ./cache/${tc_target}/firmware*/mnt
     
     case $sdk_target in
         kindlehf)
@@ -92,7 +101,7 @@ Setup_SDK() {
 
         echo "[*] Extracting firmware #$((i+1))"
         if [ -d "./cache/${tc_target}/firmware_${i}/" ]; then
-            sudo rm -rf "./cache/${tc_target}/firmware_${i}/"
+            rm -rf "./cache/${tc_target}/firmware_${i}/"
         fi
       else
         echo "Found firmware in cache - SKIPPING DOWNLOAD!"
@@ -106,7 +115,8 @@ Setup_SDK() {
 
           gunzip rootfs.img.gz
           mkdir -p mnt
-          sudo mount -o loop rootfs.img mnt
+          # extract, "dangerously" write symlinks as links, output to mnt
+          $sevenzip x -snld -omnt rootfs.img
       cd ../../..
     done
 
@@ -194,8 +204,6 @@ Setup_SDK() {
         cp -rn --remove-destination ./cache/${tc_target}/firmware_${i}/mnt/lib/* $sysroot_dir/lib/
         set -e
     done
-    sudo chown -R $USER: ${sysroot_dir}/usr/lib/*
-    sudo chown -R $USER: ${sysroot_dir}/lib/*
     echo "[*] Patching symlinks"
     set +e # Temporarially disable error checking because some of these will fail bc they're referencing nonexistent targets
     find $sysroot_dir/usr/lib -type l -ls | grep "\-> /" | grep -v "\-> $sysroot_dir" | awk -v sysroot_dir="$sysroot_dir" '{print "rm " $11 "; ln -sf " sysroot_dir $13 " " $11}' | sh
@@ -209,7 +217,7 @@ Setup_SDK() {
 
 
     echo "[*] Cleaning up"
-    sudo umount ./cache/${tc_target}/firmware*/mnt
+    rm -rf ./cache/${tc_target}/firmware*/mnt
 
     echo "===================================================================================================="
     echo "[*] Kindle (unofficial) SDK Installed"
@@ -225,8 +233,6 @@ echo "================ v2.0.0 ="
 echo
 echo
 
-echo "Please authenticate sudo for mounting"
-sudo echo # Do sudo auth beforehand in case the user leaves when we actually need it lol (the user's PC should download the firmware within the timeout window)
 cd $(dirname "$0")
 
 HELP_MSG="


### PR DESCRIPTION
7zip isn't the _most_ common of packages, but this is useful for running in Docker containers where extra privileges are needed to mount the image (even though it runs as root by default).

Oddly, `brew install sevenzip` (or anything using the packages directly from https://7-zip.org/download.html) results in a binary `7zz`, whereas Ubuntu's 7zip package installs directly as `7z`. So... we have to handle both :(

